### PR TITLE
Basic datatypes and parameter types highlighted

### DIFF
--- a/syntaxes/rinfo.tmLanguage.json
+++ b/syntaxes/rinfo.tmLanguage.json
@@ -27,8 +27,12 @@
       "match": "\\b(V|F)\\b"
     },
     {
-      "name": "support.type.rinfo",
-      "match": "\\b(boolean|numero|ES|E|S)\\b"
+      "name": "entity.name.type.rinfo",
+      "match": "\\b(boolean|numero)\\b"
+    },
+    {
+      "name": "variable.parameter.type.rinfo",
+      "match": "\\b(ES|E|S)\\b"
     },
     {
       "match": "\\+|-|\\*|/",


### PR DESCRIPTION
Antes `numero` y `boolean` no se distiguían de variables. Ahora son indentificados con el patrón "entity.name.type.rinfo", que la mayoría de los temas adoptan con un estilo diferente.
Lo mismo sucedía con los tipos de parámetro (`E`, `ES`, `S`). Ahora son identificados como "variable.parameter.type.rinfo", dándoles un estilo diferente de los parámetros que acompañan.